### PR TITLE
[GFTCodeFixer]:  Update on src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java

### DIFF
--- a/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
+++ b/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class VulnadoApplicationTests {
 
 	@Test
-	public void contextLoads() {
+    throw new UnsupportedOperationException("Method not implemented");
 	}
 
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the a1f5e50f5e49bfc90c811d9e00a999c33d73ec1e

**Description:** The pull request modifies the `VulnadoApplicationTests.java` file located in the `src/test/java/com/scalesec/vulnado` directory. Specifically, the `contextLoads` test method has been updated to throw an `UnsupportedOperationException` with the message "Method not implemented." This change effectively disables the test by marking it as unimplemented.

**Summary:** 
- **File Modified:** `src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java`
- **Changes Made:** 
  - The `contextLoads` method was altered to include the following line:
    ```java
    throw new UnsupportedOperationException("Method not implemented");
    ```
  - This replaces any previous implementation of the `contextLoads` method, effectively marking it as unimplemented.

**Recommendation:** 
1. **Testing Impact:** The `contextLoads` method is a common test in Spring Boot applications to verify that the application context loads correctly. Disabling this test by throwing an exception may lead to undetected issues in the application context. It is recommended to either implement the test properly or provide a valid reason for disabling it.
   
2. **Code Quality:** If the test is intentionally disabled, consider adding a comment explaining why it is disabled and when it will be implemented. For example:
   ```java
   // TODO: Implement contextLoads test. Currently disabled due to [reason].
   throw new UnsupportedOperationException("Method not implemented");
   ```

3. **Alternative Suggestion:** If the test is not ready for implementation, you can use the `@Disabled` annotation from JUnit to temporarily disable it without throwing an exception:
   ```java
   @Test
   @Disabled("Test not implemented yet")
   public void contextLoads() {
       // Test logic will be added here in the future
   }
   ```

**Explanation of vulnerabilities:** 
No direct vulnerabilities were introduced by this change. However, disabling the `contextLoads` test could lead to undetected issues in the application context, which might result in runtime errors or misconfigurations. It is crucial to ensure that this test is implemented before deploying the application to production.